### PR TITLE
#51: define public cover size lengths

### DIFF
--- a/kdpcover.dtx
+++ b/kdpcover.dtx
@@ -229,10 +229,10 @@
 \makeatletter
 \newcount\kdp@pages
   \kdp@pages=100
-\newlength\kdp@xsize
-  \setlength\kdp@xsize{6in}
-\newlength\kdp@ysize
-  \setlength\kdp@ysize{9in}
+\newlength\kdpxsize
+  \setlength\kdpxsize{6in}
+\newlength\kdpysize
+  \setlength\kdpysize{9in}
 \makeatother
 %    \end{macrocode}
 
@@ -261,16 +261,16 @@
     \kdp@pages=\temp
   },
   6x9/.code = {
-    \setlength\kdp@xsize{6in}
-    \setlength\kdp@ysize{9in}
+    \setlength\kdpxsize{6in}
+    \setlength\kdpysize{9in}
   },
   7x10/.code = {
-    \setlength\kdp@xsize{7in}
-    \setlength\kdp@ysize{10in}
+    \setlength\kdpxsize{7in}
+    \setlength\kdpysize{10in}
   },
   8x10/.code = {
-    \setlength\kdp@xsize{8in}
-    \setlength\kdp@ysize{10in}
+    \setlength\kdpxsize{8in}
+    \setlength\kdpysize{10in}
   },
   pages/.code = {
     \kdp@pages=#1
@@ -304,12 +304,7 @@
 %    \begin{macrocode}
 \makeatletter
 \newlength\kdp@height
-  \setlength\kdp@height{0.125in + \kdp@ysize + 0.125in}
 \newlength\kdp@width
-  \setlength\kdp@width{
-    0.125in + \kdp@xsize
-    + 0.125in + \kdp@xsize
-    + 0.0025in * \kdp@pages}
 \makeatother
 %    \end{macrocode}
 
@@ -317,13 +312,20 @@
 %    \begin{macrocode}
 \RequirePackage{geometry}
 \makeatletter
-\geometry{
-  paperwidth=\kdp@width,
-  paperheight=\kdp@height,
-  left=0pt,
-  right=0pt,
-  top=0pt,
-  bottom=0pt
+\AddToHook{begindocument/before}{%
+  \setlength\kdp@height{0.125in + \kdpysize + 0.125in}%
+  \setlength\kdp@width{
+    0.125in + \kdpxsize
+    + 0.125in + \kdpxsize
+    + 0.0025in * \kdp@pages}%
+  \geometry{
+    paperwidth=\kdp@width,
+    paperheight=\kdp@height,
+    left=0pt,
+    right=0pt,
+    top=0pt,
+    bottom=0pt
+  }%
 }
 \makeatother
 %    \end{macrocode}


### PR DESCRIPTION
Fixes #51.

This follows the maintainer suggestion in #51: the documented `\kdpxsize` and `\kdpysize` lengths are now the public size registers used by the class. The option presets update those public lengths, and the geometry calculation is delayed until `begindocument/before` so a preamble override like the documented example changes the generated page size instead of only compiling.

Validation:
- `git diff --check`
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1`
- `l3build check --engine=pdftex` on a TeX Live 2026 host with `qpdf` installed: all checks passed
- custom smoke test compiled a document with `\setlength\kdpxsize{8.1in}` and `\setlength\kdpysize{12.7in}`; `qpdf --show-object=5 kdpcover-custom.pdf` showed `/MediaBox [ 0 0 1184.581 932.4 ]`, matching the custom size plus bleed/spine calculation

No secrets or generated build artifacts are included.
